### PR TITLE
Store the Raspbian OS in the installation directory

### DIFF
--- a/app/pibakery.js
+++ b/app/pibakery.js
@@ -66,34 +66,24 @@ var piBakeryPath
 var tempBlocks = []
 
 /**
-  * @desc checks that the os and blocks exist, and sets up PiBakery
-  * @return null
-*/
-function getOsPath () {
-  if (process.platform == 'darwin') {
-    // Mac stores the OS in Application Support
-    return path.normalize('/Library/Application Support/PiBakery/os/')
-  }
-  else if (process.platform == 'win32') {
-    // Windows stores the OS in install directory
-    return path.normalize(__dirname + '/../os/')
-  }else {
-    return null
-  }
-}
+ *
+ * @desc the path to the Raspbian Operating System
+ *
+ */
+var osPath = path.normalize(__dirname + '/../os/')
 
 /**
   * @desc checks that the os and blocks exist, and sets up PiBakery
   * @return null
 */
 function initialise () {
-  fs.stat(path.normalize(getOsPath() + 'raspbian-pibakery.img'), function (error, stats) {
+  fs.stat(path.normalize(osPath + 'raspbian-pibakery.img'), function (error, stats) {
     if (error) {
       console.error(error)
-      fs.stat(path.normalize(getOsPath() + 'info.json'), function (error, stats) {
+      fs.stat(path.normalize(osPath + 'info.json'), function (error, stats) {
         if (error) {
           console.error(error)
-          fs.writeFile(path.normalize(getOsPath() + 'info.json'), '', function (error) {
+          fs.writeFile(path.normalize(osPath + 'info.json'), '', function (error) {
             if (error) {
               console.error(error)
               // Well, I have no idea what to do now. Reinstall?
@@ -109,7 +99,7 @@ function initialise () {
         }
       })
     }
-    fs.stat(path.normalize(getOsPath() + 'info.json'), function (error, stats) {
+    fs.stat(path.normalize(osPath + 'info.json'), function (error, stats) {
       if (error) {
         console.error(error)
         fixRaspbian(2)
@@ -225,7 +215,7 @@ function fixRaspbian (errorType) {
             }
             if( (response.statusCode == 200) ) {
               var raspbianVersions = JSON.parse(body)
-              md5File(path.normalize(getOsPath() + 'raspbian-pibakery.img'), function (error, sum) {
+              md5File(path.normalize(osPath + 'raspbian-pibakery.img'), function (error, sum) {
                 if (error) {
                   console.error(error)
                   alert('Unable to verify Raspbian. Please try again later, or reinstall PiBakery.')
@@ -233,7 +223,7 @@ function fixRaspbian (errorType) {
                 }
                 for ( var i = 0; i < raspbianVersions.length; i++) {
                   if (raspbianVersions[i].hash == sum) {
-                    fs.writeJson(path.normalize(getOsPath() + 'info.json'), {version: raspbianVersions[i].version, uncompressedMD5: raspbianVersions[i].hash, raspbianDate: raspbianVersions[i].original}, function (error) {
+                    fs.writeJson(path.normalize(osPath + 'info.json'), {version: raspbianVersions[i].version, uncompressedMD5: raspbianVersions[i].hash, raspbianDate: raspbianVersions[i].original}, function (error) {
                       if (error) {
                         console.error(error)
                         displayError('Auto-Fix Failed', 'Unable to update info file', 'Please reinstall PiBakery to fix this issue.')
@@ -441,7 +431,7 @@ function checkForBlockUpdates () {
   * @return null
 */
 function checkForRaspbianUpdates (cb) {
-  fs.readFile(path.normalize(getOsPath() + 'info.json'), 'utf8', function (error, data) {
+  fs.readFile(path.normalize(osPath + 'info.json'), 'utf8', function (error, data) {
     if (error) {
       console.error(error)
       return
@@ -792,7 +782,7 @@ function updateRaspbian (src, raspbian7zHash, raspbianImgHash, extractedSize, ne
         alert('Unable to connect to server.\nTry updating later.')
       }
     }else {
-      var saveName = path.normalize(getOsPath() + 'raspbian-pibakery.7z')
+      var saveName = path.normalize(osPath + 'raspbian-pibakery.7z')
       var raspbianDownload = wget.download(src, saveName, {})
       raspbianDownload.on('error', function (error) {
         console.error(error)
@@ -820,7 +810,7 @@ function updateRaspbian (src, raspbian7zHash, raspbianImgHash, extractedSize, ne
               }
             }else {
               var extractProgress
-              extract7z(saveName, path.normalize(getOsPath()), function (error) {
+              extract7z(saveName, path.normalize(osPath), function (error) {
                 clearInterval(extractProgress)
                 if (error) {
                   console.error(error)
@@ -867,14 +857,14 @@ function updateRaspbian (src, raspbian7zHash, raspbianImgHash, extractedSize, ne
                             displayError('Raspbian Update Failed', 'Unable to remove 7z', 'This might cause unexpected behaviour whilst using PiBakery.')
                           }
                         }else {
-                          fs.remove(path.normalize(getOsPath() + 'raspbian-pibakery.img'), function (error) // delete the old raspbian.img
+                          fs.remove(path.normalize(osPath + 'raspbian-pibakery.img'), function (error) // delete the old raspbian.img
                           {
                             if (error && (! fixing)) // if we're fixing the .img won't exist, so ignore this error.
                             {
                               console.error(error)
                               displayError('Raspbian Update Failed', 'Removal Failed', 'This might cause unexpected behaviour whilst using PiBakery.')
                             }else {
-                              fs.rename(filepath, path.normalize(getOsPath() + 'raspbian-pibakery.img'), function (error) // rename new-raspbian.img to raspbian.img
+                              fs.rename(filepath, path.normalize(osPath + 'raspbian-pibakery.img'), function (error) // rename new-raspbian.img to raspbian.img
                               {
                                 if (error) {
                                   console.error(error)
@@ -884,7 +874,7 @@ function updateRaspbian (src, raspbian7zHash, raspbianImgHash, extractedSize, ne
                                     displayError('Raspbian Update Failed', 'Processing Failed', 'This might cause unexpected behaviour whilst using PiBakery.')
                                   }
                                 }else {
-                                  fs.writeFile(path.normalize(getOsPath() + 'info.json'), newOsInfo, function (error) {
+                                  fs.writeFile(path.normalize(osPath + 'info.json'), newOsInfo, function (error) {
                                     if (error) {
                                       console.error(error)
                                       if (fixing) {
@@ -974,8 +964,8 @@ function updateRaspbian (src, raspbian7zHash, raspbianImgHash, extractedSize, ne
 function getExtractedPath (callback, currentNumber) {
   if (typeof currentNumber === 'undefined') { currentNumber = 0; }
   var paths = [
-    path.normalize(getOsPath() + 'raspbian-pibakery-new.img'),
-    path.normalize(getOsPath() + '../raspbian-pibakery-new.img')
+    path.normalize(osPath + 'raspbian-pibakery-new.img'),
+    path.normalize(osPath + '../raspbian-pibakery-new.img')
   ]
   if (currentNumber >= paths.length) {
     callback(false)
@@ -1445,7 +1435,7 @@ function displayError (titleMsg, errorMsg, behaviourMsg) {
 */
 function writeToSd () {
   writeTryCount = 0
-  var imageFile = path.normalize(getOsPath() + 'raspbian-pibakery.img')
+  var imageFile = path.normalize(osPath + 'raspbian-pibakery.img')
 
   createSdChooser(function (devicePath, name) {
     var choice = dialog.showMessageBox(


### PR DESCRIPTION
This change standardises the OS storage location across Windows, OSX and Linux.
It has been tested on Windows 10 and Linux Debian.

Note: If deemed suitable, please test on OSX.

Based on communication with David this patch is only applicable temporarely to my own OS needs as I exclusively use Linux. The needs for such a change will be overridden by David's enhancements for Linux.
